### PR TITLE
Reuse facepaint for responsive values and provide media

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,15 +1,15 @@
 {
   "dist/index.esm.js": {
-    "bundled": 8325,
-    "minified": 4797,
-    "gzipped": 1371,
+    "bundled": 7661,
+    "minified": 4741,
+    "gzipped": 1338,
     "treeshaked": {
       "rollup": {
-        "code": 161,
-        "import_statements": 161
+        "code": 202,
+        "import_statements": 202
       },
       "webpack": {
-        "code": 1220
+        "code": 1327
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/index.esm.js": {
-    "bundled": 7789,
-    "minified": 4373,
-    "gzipped": 1343,
+    "bundled": 8325,
+    "minified": 4797,
+    "gzipped": 1371,
     "treeshaked": {
       "rollup": {
         "code": 161,

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ The default scale is `[ 0, 4, 8, 16, 32, 64, 128, 256 ]`.
 
 The Flex and Box components use a mobile-first responsive approach, where any value set works from that breakpoint and wider. Breakpoints are hard-coded to the following min-widths: `[768, 1280, 1920]`.
 
+### media(styles)
+
+An utility function which allows to write responsive styles similar to Flex/Box props.
+
+_Note: `media()` can be called only inside of component render._
+
+```js
+const Component = () => {
+  return (
+    <Box css={media({ background: ["#000", "#fff"] })}>
+      <div className={css(media({ color: ["#fff", "#000"] }))}>Content</div>
+    </Box>
+  );
+};
+```
+
 ## What is the different from grid-styled or @rebass/grid
 
 - react-system has less dependencies and esm support which leads to smaller bundle size
@@ -111,25 +127,6 @@ The Flex and Box components use a mobile-first responsive approach, where any va
 - emotion only support; by not using react-emotion this project works well in concurrent mode
 - wrong numeric paddings, margins, width and height are clamped to their possible values
 - this project uses internal context reader to eliminate nested elements in `Flex` and `Box` components
-
-### media(styles)
-
-An utility function which allows to write responsive styles similar to Flex/Box props.
-
-*Note: `media()` can be called only inside of component render.*
-
-```js
-const Component = () => {
-  return (
-    <Box css={media({ background: ['#000', '#fff'] })}>
-      <div className={css(media({ color: ['#fff', '#000'] }))}>
-        Content
-      </div>
-    </Box>
-  )
-}
-
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ The Flex and Box components use a mobile-first responsive approach, where any va
 - wrong numeric paddings, margins, width and height are clamped to their possible values
 - this project uses internal context reader to eliminate nested elements in `Flex` and `Box` components
 
+### media(styles)
+
+An utility function which allows to write responsive styles similar to Flex/Box props.
+
+*Note: `media()` can be called only inside of component render.*
+
+```js
+const Component = () => {
+  return (
+    <Box css={media({ background: ['#000', '#fff'] })}>
+      <div className={css(media({ color: ['#fff', '#000'] }))}>
+        Content
+      </div>
+    </Box>
+  )
+}
+
+```
+
 ## License
 
 MIT &copy; [Bogdan Chadkin](mailto:trysound@yandex.ru)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-size-snapshot": "^0.7.0"
   },
+  "peerDependencies": {
+    "react": "^16.6.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "emotion": "^9.2.12"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "emotion": "^9.2.12"
+    "emotion": "^9.2.12",
+    "facepaint": "^1.2.1",
+    "tiny-invariant": "^1.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,8 +3,9 @@
 import * as React from "react";
 import TestRenderer from "react-test-renderer";
 import { renderToString } from "react-dom/server";
+import { css } from "emotion";
 import { renderStylesToString } from "emotion-server";
-import { Box, Flex } from "./src/index.js";
+import { Box, Flex, media } from "./src/index.js";
 
 declare var test: Function;
 declare var expect: Function;
@@ -575,4 +576,56 @@ test("concat className with prop", () => {
   />
 </div>
 `);
+});
+
+test("media allow to pass responsive styles to css prop and emotion css()", () => {
+  const App = () => (
+    <div className={css(media({ display: ["block", "none"], color: "#fff" }))}>
+      <Box css={media({ overflow: ["hidden", "auto"], color: "#000" })} />
+    </div>
+  );
+
+  expect(TestRenderer.create(<App />).toJSON()).toMatchInlineSnapshot(`
+.emotion-0 {
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+}
+
+.emotion-2 {
+  display: block;
+  color: #fff;
+}
+
+@media screen and (min-width:48em) {
+  .emotion-2 {
+    display: none;
+  }
+}
+
+.emotion-1 {
+  overflow: hidden;
+  color: #000;
+}
+
+@media screen and (min-width:48em) {
+  .emotion-1 {
+    overflow: auto;
+  }
+}
+
+<div
+  className="emotion-2"
+>
+  <div
+    className="emotion-0 emotion-1"
+  />
+</div>
+`);
+});
+
+test("media called outside of component render throw an error", () => {
+  expect(() => {
+    media({ display: "block" });
+  }).toThrowError("Calling media outside of component render is not allowed");
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2084,6 +2084,10 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
+facepaint@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/facepaint/-/facepaint-1.2.1.tgz#89929e601b15227278c53c516f764fc462b09c33"
+
 fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
@@ -4821,6 +4825,10 @@ timers-browserify@^2.0.4:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.10.tgz#1d28e3d2aadf1d5a5996c4e9f95601cd053480ae"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-invariant@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.3.tgz#91efaaa0269ccb6271f0296aeedb05fc3e067b7a"
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
In this diff I migrated from custom handling responsive values to
[facepaint](https://github.com/emotion-js/facepaint) which works quite well with them and tested carefully.

Its instance I reused inside of `media()` utility which allows to write
any css like responsive values.

For my app it will eliminate the need to styled-system.