### PR TITLE
Move responsive out of useSystem

### DIFF
--- a/pages/system.js
+++ b/pages/system.js
@@ -1,10 +1,11 @@
 // @flow
 
 import * as React from "react";
-import { Box, useSystem } from "../src/system.js";
+import { Box, useSystem, useResponsive } from "../src/system.js";
 
 const Page = () => {
-  const { media, responsive } = useSystem();
+  const { media } = useSystem();
+  const responsive = useResponsive();
 
   return (
     <>

--- a/src/system.js
+++ b/src/system.js
@@ -146,9 +146,8 @@ type MediaPropStyles = {
 
 type Styles = $ReadOnlyArray<BasicStyles> | MediaPropStyles;
 
-export const useSystem = () => {
+export const useResponsive = () => {
   const context = React.useContext(SystemContext);
-  const media = makeMedia(context);
   const [index, setIndex] = React.useState(0);
 
   React.useEffect(() => {
@@ -173,6 +172,13 @@ export const useSystem = () => {
     return values[Math.max(0, Math.min(index, values.length - 1))];
   };
 
+  return responsive;
+};
+
+export const useSystem = () => {
+  const context = React.useContext(SystemContext);
+  const media = makeMedia(context);
+
   const toSpace = value => {
     return Array.isArray(value)
       ? value.map(item => getSpace(item, context))
@@ -196,7 +202,6 @@ export const useSystem = () => {
 
   return {
     media,
-    responsive,
     pt,
     pr,
     pb,

--- a/src/system.js
+++ b/src/system.js
@@ -150,23 +150,26 @@ export const useResponsive = () => {
   const context = React.useContext(SystemContext);
   const [index, setIndex] = React.useState(0);
 
-  React.useEffect(() => {
-    const handleResize = () => {
-      let currentIndex = 0;
-      context.breakpoints.forEach((bp, i) => {
-        if (window.matchMedia(makeQuery(bp)).matches) {
-          // one more for smallest value
-          currentIndex = i + 1;
-        }
-      });
-      setIndex(currentIndex);
-    };
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  });
+  React.useEffect(
+    () => {
+      const handleResize = () => {
+        let currentIndex = 0;
+        context.breakpoints.forEach((bp, i) => {
+          if (window.matchMedia(makeQuery(bp)).matches) {
+            // one more for smallest value
+            currentIndex = i + 1;
+          }
+        });
+        setIndex(currentIndex);
+      };
+      handleResize();
+      window.addEventListener("resize", handleResize);
+      return () => {
+        window.removeEventListener("resize", handleResize);
+      };
+    },
+    [context]
+  );
 
   const responsive = <T>(values: $ReadOnlyArray<T>): T => {
     return values[Math.max(0, Math.min(index, values.length - 1))];

--- a/test.js
+++ b/test.js
@@ -6,7 +6,13 @@ import TestRenderer from "react-test-renderer";
 import { renderToString } from "react-dom/server";
 import { css } from "emotion";
 import { renderStylesToString } from "emotion-server";
-import { Box, Flex, media as mediaUtil, useSystem } from "./src/system.js";
+import {
+  Box,
+  Flex,
+  media as mediaUtil,
+  useSystem,
+  useResponsive
+} from "./src/system.js";
 
 declare var jest: Function;
 declare var test: Function;
@@ -740,7 +746,7 @@ test("system media allow to pass array of rules", () => {
 test("system responsive allows to get value in system like style", () => {
   let result;
   const App = () => {
-    const { responsive } = useSystem();
+    const responsive = useResponsive();
     result = responsive([1, 2, 3, 4]);
     return null;
   };


### PR DESCRIPTION
For now every Box Flex and every useSystem subscribed on window `resize` event, rerenders on first render,
this causes a lot of overhead on initial render, on resize.

Also this even causes `gc` because on every render unsubscription - subscription occured.